### PR TITLE
Handle migrations with file based versioning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,11 @@ module Sagittarius
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    # Use SQL instead of Active Record's schema dumper when creating the database.
+    # This is necessary if your schema can't be completely dumped by the schema dumper,
+    # like if you have constraints or database-specific column types
+    config.active_record.schema_format = :sql
+
     Rails.application.default_url_options =
       if ENV['SAGITTARIUS_RAILS_HOSTNAME'].nil?
         {

--- a/config/initializers/active_record_schema_migrations.rb
+++ b/config/initializers/active_record_schema_migrations.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/config/initializers/active_record_schema_versions.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+# rubocop:disable Layout/LineLength
+Rails.application.config.to_prepare do
+  # Patch to write version information as empty files under the db/schema_migrations directory
+  # This is intended to reduce potential for merge conflicts in db/structure.sql
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(Sagittarius::Database::PostgresqlAdapter::DumpSchemaVersionsMixin)
+  # Patch to load version information from empty files under the db/schema_migrations directory
+  ActiveRecord::Tasks::PostgreSQLDatabaseTasks.prepend(Sagittarius::Database::PostgresqlDatabaseTasks::LoadSchemaVersionsMixin)
+end
+# rubocop:enable Layout/LineLength

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,16 @@
+CREATE TABLE ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+CREATE TABLE schema_migrations (
+    version character varying NOT NULL
+);
+
+ALTER TABLE ONLY ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+ALTER TABLE ONLY schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);

--- a/lib/sagittarius/database/postgresql_adapter/dump_schema_versions_mixin.rb
+++ b/lib/sagittarius/database/postgresql_adapter/dump_schema_versions_mixin.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/lib/gitlab/database/postgresql_adapter/dump_schema_versions_mixin.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+module Sagittarius
+  module Database
+    module PostgresqlAdapter
+      module DumpSchemaVersionsMixin
+        extend ActiveSupport::Concern
+
+        def dump_schema_information
+          # rubocop:disable Rails/SkipsModelValidations -- not an active record object
+          Sagittarius::Database::SchemaMigrations.touch_all(self) unless Rails.env.production?
+          # rubocop:enable Rails/SkipsModelValidations
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/sagittarius/database/postgresql_database_tasks/load_schema_versions_mixin.rb
+++ b/lib/sagittarius/database/postgresql_database_tasks/load_schema_versions_mixin.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/lib/gitlab/database/postgresql_database_tasks/load_schema_versions_mixin.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+module Sagittarius
+  module Database
+    module PostgresqlDatabaseTasks
+      module LoadSchemaVersionsMixin
+        extend ActiveSupport::Concern
+
+        def structure_load(...)
+          super(...)
+
+          Sagittarius::Database::SchemaMigrations.load_all(connection)
+        end
+      end
+    end
+  end
+end

--- a/lib/sagittarius/database/schema_cleaner.rb
+++ b/lib/sagittarius/database/schema_cleaner.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/lib/gitlab/database/schema_cleaner.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+module Sagittarius
+  module Database
+    class SchemaCleaner
+      attr_reader :original_schema
+
+      def initialize(original_schema)
+        @original_schema = original_schema
+      end
+
+      def clean(io)
+        structure = original_schema.dup
+
+        # Remove noise
+        structure.gsub!(/^COMMENT ON EXTENSION.*/, '')
+        structure.gsub!(/^SET.+/, '')
+        structure.gsub!(/^SELECT pg_catalog\.set_config\('search_path'.+/, '')
+        structure.gsub!(/^--.*/, "\n")
+
+        # We typically don't assume we're working with the public schema.
+        # pg_dump uses fully qualified object names though, since we have multiple schemas
+        # in the database.
+        #
+        # The intention here is to not introduce an assumption about the standard schema,
+        # unless we have a good reason to do so.
+        structure.gsub!(/public\.(\w+)/, '\1')
+        structure.gsub!(
+          /CREATE EXTENSION IF NOT EXISTS (\w+) WITH SCHEMA public;/,
+          'CREATE EXTENSION IF NOT EXISTS \1;'
+        )
+
+        structure.gsub!(/\n{3,}/, "\n\n")
+
+        io << structure.strip
+        io << "\n"
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/sagittarius/database/schema_migrations.rb
+++ b/lib/sagittarius/database/schema_migrations.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/lib/gitlab/database/schema_migrations.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+module Sagittarius
+  module Database
+    module SchemaMigrations
+      module_function
+
+      def touch_all(connection)
+        context = Sagittarius::Database::SchemaMigrations::Context.new(connection)
+
+        # rubocop:disable Rails/SkipsModelValidations -- not an active record object
+        Sagittarius::Database::SchemaMigrations::Migrations.new(context).touch_all
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      def load_all(connection)
+        context = Sagittarius::Database::SchemaMigrations::Context.new(connection)
+
+        Sagittarius::Database::SchemaMigrations::Migrations.new(context).load_all
+      end
+    end
+  end
+end

--- a/lib/sagittarius/database/schema_migrations/context.rb
+++ b/lib/sagittarius/database/schema_migrations/context.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/lib/gitlab/database/schema_migrations/context.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+module Sagittarius
+  module Database
+    module SchemaMigrations
+      class Context
+        attr_reader :connection
+
+        class_attribute :default_schema_migrations_path, default: 'db/schema_migrations'
+
+        def initialize(connection)
+          @connection = connection
+        end
+
+        def schema_directory
+          @schema_directory ||= Rails.root.join(database_schema_migrations_path).to_s
+        end
+
+        def versions_to_create
+          versions_from_database = @connection.schema_migration.versions
+          versions_from_migration_files = @connection.migration_context.migrations.map { |m| m.version.to_s }
+
+          versions_from_database & versions_from_migration_files
+        end
+
+        private
+
+        def database_name
+          @database_name ||= @connection.pool.db_config.name
+        end
+
+        def database_schema_migrations_path
+          @connection.pool.db_config.configuration_hash[:schema_migrations_path] ||
+            self.class.default_schema_migrations_path
+        end
+      end
+    end
+  end
+end

--- a/lib/sagittarius/database/schema_migrations/migrations.rb
+++ b/lib/sagittarius/database/schema_migrations/migrations.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/lib/gitlab/database/schema_migrations/migrations.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+module Sagittarius
+  module Database
+    module SchemaMigrations
+      class Migrations
+        MIGRATION_VERSION_GLOB = '20[0-9][0-9]*'
+
+        def initialize(context)
+          @context = context
+        end
+
+        def touch_all
+          return unless @context.versions_to_create.any?
+
+          version_filepaths = version_filenames.map { |f| File.join(schema_directory, f) }
+          FileUtils.rm(version_filepaths)
+
+          @context.versions_to_create.each do |version|
+            version_filepath = File.join(schema_directory, version)
+
+            File.open(version_filepath, 'w') do |file|
+              file << Digest::SHA256.hexdigest(version)
+            end
+          end
+        end
+
+        def load_all
+          return if version_filenames.empty?
+
+          values = version_filenames.map { |vf| "('#{@context.connection.quote_string(vf)}')" }
+
+          @context.connection.execute(<<~SQL.squish)
+            INSERT INTO schema_migrations (version)
+            VALUES #{values.join(',')}
+            ON CONFLICT DO NOTHING
+          SQL
+        end
+
+        private
+
+        def schema_directory
+          @context.schema_directory
+        end
+
+        def version_filenames
+          @version_filenames ||= Dir.glob(MIGRATION_VERSION_GLOB, base: schema_directory)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :sagittarius do
+  namespace :db do
+    desc 'This adjusts and cleans db/structure.sql - it runs after db:schema:dump'
+    task clean_structure_sql: :environment do |task_name|
+      ActiveRecord::Base.configurations
+                        .configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)
+                        .each do |db_config|
+        structure_file = ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(db_config)
+
+        schema = File.read(structure_file)
+
+        File.open(structure_file, 'wb+') do |io|
+          Sagittarius::Database::SchemaCleaner.new(schema).clean(io)
+        end
+      end
+
+      # Allow this task to be called multiple times, as happens when running db:migrate:redo
+      Rake::Task[task_name].reenable
+    end
+
+    # Inform Rake that custom tasks should be run every time rake db:schema:dump is run
+    Rake::Task['db:schema:dump'].enhance do
+      Rake::Task['sagittarius:db:clean_structure_sql'].invoke
+    end
+  end
+end

--- a/spec/lib/sagittarius/database/postgresql_adapter/dump_schema_versions_mixin_spec.rb
+++ b/spec/lib/sagittarius/database/postgresql_adapter/dump_schema_versions_mixin_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/spec/lib/gitlab/database/postgresql_adapter/dump_schema_versions_mixin_spec.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+require 'rails_helper'
+
+RSpec.describe Sagittarius::Database::PostgresqlAdapter::DumpSchemaVersionsMixin do
+  let(:instance_class) do
+    klass = Class.new do
+      def dump_schema_information
+        original_dump_schema_information
+      end
+
+      def original_dump_schema_information; end
+    end
+
+    klass.prepend(described_class)
+
+    klass
+  end
+
+  let(:instance) { instance_class.new }
+
+  it 'calls SchemaMigrations touch_all and skips original implementation', :aggregate_failures do
+    allow(Sagittarius::Database::SchemaMigrations).to receive(:touch_all)
+    allow(instance).to receive(:original_dump_schema_information)
+
+    instance.dump_schema_information
+
+    expect(Sagittarius::Database::SchemaMigrations).to have_received(:touch_all).with(instance)
+    expect(instance).not_to have_received(:original_dump_schema_information)
+  end
+
+  it 'does not call touch_all in production' do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+    allow(Sagittarius::Database::SchemaMigrations).to receive(:touch_all)
+
+    instance.dump_schema_information
+
+    expect(Sagittarius::Database::SchemaMigrations).not_to have_received(:touch_all)
+  end
+end

--- a/spec/lib/sagittarius/database/postgresql_database_tasks/load_schema_versions_mixin_spec.rb
+++ b/spec/lib/sagittarius/database/postgresql_database_tasks/load_schema_versions_mixin_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/spec/lib/gitlab/database/postgresql_database_tasks/load_schema_versions_mixin_spec.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+require 'rails_helper'
+
+RSpec.describe Sagittarius::Database::PostgresqlDatabaseTasks::LoadSchemaVersionsMixin do
+  let(:instance_class) do
+    klass = Class.new do
+      def structure_load
+        original_structure_load
+      end
+
+      def original_structure_load; end
+      def connection; end
+    end
+
+    klass.prepend(described_class)
+
+    klass
+  end
+
+  let(:instance) { instance_class.new }
+
+  it 'calls SchemaMigrations load_all', :aggregate_failures do
+    connection = double('connection') # rubocop:disable RSpec/VerifiedDoubles -- we don't need an actual connection here
+    allow(instance).to receive(:connection).and_return(connection)
+    allow(instance).to receive(:original_structure_load)
+    allow(Sagittarius::Database::SchemaMigrations).to receive(:load_all)
+
+    instance.structure_load
+
+    expect(instance).to have_received(:original_structure_load).ordered
+    expect(Sagittarius::Database::SchemaMigrations).to have_received(:load_all).with(connection).ordered
+  end
+end

--- a/spec/lib/sagittarius/database/schema_migrations/context_spec.rb
+++ b/spec/lib/sagittarius/database/schema_migrations/context_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/spec/lib/gitlab/database/schema_migrations/context_spec.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+require 'rails_helper'
+
+RSpec.describe Sagittarius::Database::SchemaMigrations::Context do
+  let(:connection_class) { ActiveRecord::Base }
+  let(:connection) { connection_class.connection }
+
+  let(:context) { described_class.new(connection) }
+
+  it '#schema_directory returns db/schema_migrations' do
+    expect(context.schema_directory).to eq(Rails.root.join(described_class.default_schema_migrations_path).to_s)
+  end
+
+  describe '#versions_to_create' do
+    before do
+      # rubocop:disable RSpec/MessageChain -- we are mocking into active records structure
+      allow(connection).to receive_message_chain(:schema_migration, :versions).and_return(migrated_versions)
+
+      migrations_struct = Struct.new(:version)
+      migrations = file_versions.map { |version| migrations_struct.new(version) }
+      allow(connection).to receive_message_chain(:migration_context, :migrations).and_return(migrations)
+      # rubocop:enable RSpec/MessageChain
+    end
+
+    # rubocop:disable RSpec/IndexedLet -- these indexes do make sense
+    let(:version1) { '20200123' }
+    let(:version2) { '20200410' }
+    let(:version3) { '20200602' }
+    let(:version4) { '20200809' }
+    # rubocop:enable RSpec/IndexedLet
+
+    let(:file_versions) { [version1, version2, version3, version4] }
+    let(:migrated_versions) { file_versions }
+
+    context 'when migrated versions is the same as migration file versions' do
+      it 'returns migrated versions' do
+        expect(context.versions_to_create).to eq(migrated_versions)
+      end
+    end
+
+    context 'when migrated versions is subset of migration file versions' do
+      let(:migrated_versions) { [version1, version2] }
+
+      it 'returns migrated versions' do
+        expect(context.versions_to_create).to eq(migrated_versions)
+      end
+    end
+
+    context 'when migrated versions is superset of migration file versions' do
+      let(:migrated_versions) { file_versions + ['20210809'] }
+
+      it 'returns file versions' do
+        expect(context.versions_to_create).to eq(file_versions)
+      end
+    end
+
+    context 'when migrated versions has slightly different versions to migration file versions' do
+      let(:migrated_versions) { [version1, version2, version3, version4, '20210101'] }
+      let(:file_versions) { [version1, version2, version3, version4, '20210102'] }
+
+      it 'returns the common set' do
+        expect(context.versions_to_create).to eq([version1, version2, version3, version4])
+      end
+    end
+  end
+end

--- a/spec/lib/sagittarius/database/schema_migrations/migrations_spec.rb
+++ b/spec/lib/sagittarius/database/schema_migrations/migrations_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Heavily inspired by the implementation of GitLab
+# (https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/spec/lib/gitlab/database/schema_migrations/migrations_spec.rb)
+# which is licensed under a modified version of the MIT license which can be found at
+# https://gitlab.com/gitlab-org/gitlab/-/blob/7983d2a2203aff265fae479d7c1b7066858d1265/LICENSE
+#
+# The code might have been modified to accommodate for the needs of this project
+
+require 'rails_helper'
+
+RSpec.describe Sagittarius::Database::SchemaMigrations::Migrations do
+  let(:connection) { ApplicationRecord.connection }
+  let(:context) { Sagittarius::Database::SchemaMigrations::Context.new(connection) }
+
+  let(:migrations) { described_class.new(context) }
+
+  describe '#touch_all' do
+    # rubocop:disable RSpec/IndexedLet -- these indexes do make sense
+    let(:version1) { '20200123' }
+    let(:version2) { '20200410' }
+    let(:version3) { '20200602' }
+    let(:version4) { '20200809' }
+    # rubocop:enable RSpec/IndexedLet
+
+    let(:relative_schema_directory) { 'db/schema_migrations' }
+
+    it 'creates a file containing a checksum for each version with a matching migration', :aggregate_failures do
+      Dir.mktmpdir do |tmpdir|
+        schema_directory = Pathname.new(tmpdir).join(relative_schema_directory)
+        FileUtils.mkdir_p(schema_directory)
+
+        old_version_filepath = schema_directory.join('20200101')
+        FileUtils.touch(old_version_filepath)
+
+        expect(File.exist?(old_version_filepath)).to be(true)
+
+        allow(context).to receive_messages(schema_directory: schema_directory, versions_to_create: [version1, version2])
+
+        migrations.touch_all # rubocop:disable Rails/SkipsModelValidations -- not an active record object
+
+        expect(File.exist?(old_version_filepath)).to be(false)
+
+        [version1, version2].each do |version|
+          version_filepath = schema_directory.join(version)
+          expect(File.exist?(version_filepath)).to be(true)
+
+          hashed_value = Digest::SHA256.hexdigest(version)
+          expect(File.read(version_filepath)).to eq(hashed_value)
+        end
+
+        [version3, version4].each do |version|
+          version_filepath = schema_directory.join(version)
+          expect(File.exist?(version_filepath)).to be(false)
+        end
+      end
+    end
+  end
+
+  describe '#load_all' do
+    before do
+      allow(migrations).to receive(:version_filenames).and_return(filenames)
+    end
+
+    context 'when there are no version files' do
+      let(:filenames) { [] }
+
+      it 'does nothing', :aggregate_failures do
+        allow(connection).to receive(:quote_string)
+        allow(connection).to receive(:execute)
+
+        migrations.load_all
+
+        expect(connection).not_to have_received(:quote_string)
+        expect(connection).not_to have_received(:execute)
+      end
+    end
+
+    context 'when there are version files', :aggregate_failures do
+      let(:filenames) { %w[123 456 789] }
+
+      it 'inserts the missing versions into schema_migrations' do
+        filenames.each do |filename|
+          allow(connection).to receive(:quote_string).with(filename).and_return(filename)
+        end
+        allow(connection).to receive(:execute)
+
+        migrations.load_all
+
+        filenames.each do |filename|
+          expect(connection).to have_received(:quote_string).with(filename)
+        end
+        expect(connection).to have_received(:execute).with(<<~SQL.squish)
+          INSERT INTO schema_migrations (version)
+          VALUES ('123'),('456'),('789')
+          ON CONFLICT DO NOTHING
+        SQL
+      end
+    end
+  end
+end


### PR DESCRIPTION
This prevents creating merge conflicts at the schema version section of the schema file.