### PR TITLE
Fix flaky license test

### DIFF
--- a/ee/spec/models/namespace_license_spec.rb
+++ b/ee/spec/models/namespace_license_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe NamespaceLicense do
       create(
         :namespace_license,
         namespace: namespace,
-        start_date: Time.zone.today + 1,
-        end_date: Time.zone.today + 2
+        start_date: Time.zone.today + 2,
+        end_date: Time.zone.today + 3
       )
 
       expect(described_class.load_license(namespace)).to eq(current_license)


### PR DESCRIPTION
The license test is flaky when it is executed in the hours of a date change. Increasing the start date from one to two days in the future solves this problem