### PR TITLE
Remove docker-api gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,6 @@ gem 'lograge', '~> 0.14.0'
 
 gem 'declarative_policy', '~> 1.1'
 
-gem 'docker-api', '~> 2.2'
-
 gem 'code0-license', '~> 0.2.0'
 
 gem 'good_job', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,14 +101,10 @@ GEM
     declarative_policy (1.1.0)
     diff-lcs (1.5.1)
     docile (1.4.0)
-    docker-api (2.3.0)
-      excon (>= 0.64.0)
-      multi_json
     drb (2.2.1)
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
-    excon (0.111.0)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -167,7 +163,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.2)
-    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     net-imap (0.4.16)
@@ -357,7 +352,6 @@ DEPENDENCIES
   database_cleaner-active_record (~> 2.1)
   debug
   declarative_policy (~> 1.1)
-  docker-api (~> 2.2)
   factory_bot_rails (~> 6.2)
   good_job (~> 4.0)
   graphql (~> 2.1)


### PR DESCRIPTION
The `docker-api` gem was used for the orchestrator that got removed in #305 as part of #272 