### PR TITLE
Fix GRPC server blocking interrupt of RSpec

### DIFF
--- a/bin/grpc_server
+++ b/bin/grpc_server
@@ -3,4 +3,24 @@
 
 require_relative '../config/environment'
 
-Sagittarius::Grpc::Launcher.new.start_blocking
+launcher = Sagittarius::Grpc::Launcher.new
+
+stop_signals = %w[QUIT INT TERM]
+stop_read, stop_write = IO.pipe
+
+stop_signals.each do |signal|
+  Signal.trap(signal) do
+    stop_write.puts(signal)
+  end
+end
+
+launcher.start
+
+while (readable_io = IO.select([stop_read]))
+  signal = readable_io.first[0].gets.strip
+
+  if stop_signals.include?(signal)
+    launcher.stop
+    break
+  end
+end

--- a/lib/sagittarius/grpc/launcher.rb
+++ b/lib/sagittarius/grpc/launcher.rb
@@ -7,7 +7,7 @@ module Sagittarius
 
       HOST = '0.0.0.0:50051'
 
-      def load
+      def create_server
         @server = GRPC::RpcServer.new(interceptors: [
           Sagittarius::Middleware::Grpc::Context.new,
           Sagittarius::Middleware::Grpc::Logger.new,
@@ -26,9 +26,9 @@ module Sagittarius
       end
 
       def run_server!
-        load if @server.nil?
+        create_server if @server.nil?
         logger.info('Running server')
-        @server.run_till_terminated_or_interrupted(%w[QUIT INT TERM])
+        @server.run_till_terminated_or_interrupted([])
       end
 
       def run_stream_listener!
@@ -36,14 +36,9 @@ module Sagittarius
       end
 
       def start
-        load
+        create_server
         @stream_thread = Thread.new { run_stream_listener! }
         @server_thread = Thread.new { run_server! }
-      end
-
-      def start_blocking
-        start
-        @server_thread.join # Wait for the server thread to finish because the program would end otherwise
       end
 
       def stop


### PR DESCRIPTION
The `GRPC::RpcServer` was run with `run_till_terminated_or_interrupted` listening on the `QUIT`, `INT` and `TERM` signals. This however replaced the original signal traps from RSpec, preventing its interruption after the GRPC server was started.

To fix this, the signal traps are moved into the entrypoint, so they are not registered during RSpec and RSpec continues to handle the signals and shutting down the server.