### PR TITLE
Adjust ReferenceValue to newer frontend developments

### DIFF
--- a/app/graphql/types/reference_value_type.rb
+++ b/app/graphql/types/reference_value_type.rb
@@ -9,9 +9,13 @@ module Types
     field :data_type_identifier, Types::DataTypeIdentifierType,
           null: false, description: 'The identifier of the data type this reference value belongs to.'
 
-    field :primary_level, Int, null: false, description: 'The primary level of the reference value.'
-    field :secondary_level, Int, null: false, description: 'The secondary level of the reference value.'
-    field :tertiary_level, Int, null: true, description: 'The tertiary level of the reference value, if applicable.'
+    # field :primary_level, Int, null: false, description: 'The primary level of the reference value.'
+    # field :secondary_level, Int, null: false, description: 'The secondary level of the reference value.'
+    # field :tertiary_level, Int, null: true, description: 'The tertiary level of the reference value, if applicable.'
+
+    field :depth, Int, null: false, description: 'The depth of the reference value.'
+    field :node, Int, null: false, description: 'The node of the reference value.'
+    field :scope, [Int], null: false, description: 'The scope of the reference value.'
 
     field :reference_path, [Types::ReferencePathType], null: false,
                                                        description: 'The paths associated with this reference value.'

--- a/docs/graphql/object/referencevalue.md
+++ b/docs/graphql/object/referencevalue.md
@@ -10,10 +10,10 @@ Represents a reference value in the system.
 |------|------|-------------|
 | `createdAt` | [`Time!`](../scalar/time.md) | Time when this ReferenceValue was created |
 | `dataTypeIdentifier` | [`DataTypeIdentifier!`](../object/datatypeidentifier.md) | The identifier of the data type this reference value belongs to. |
+| `depth` | [`Int!`](../scalar/int.md) | The depth of the reference value. |
 | `id` | [`ReferenceValueID!`](../scalar/referencevalueid.md) | Global ID of this ReferenceValue |
-| `primaryLevel` | [`Int!`](../scalar/int.md) | The primary level of the reference value. |
+| `node` | [`Int!`](../scalar/int.md) | The node of the reference value. |
 | `referencePath` | [`[ReferencePath!]!`](../object/referencepath.md) | The paths associated with this reference value. |
-| `secondaryLevel` | [`Int!`](../scalar/int.md) | The secondary level of the reference value. |
-| `tertiaryLevel` | [`Int`](../scalar/int.md) | The tertiary level of the reference value, if applicable. |
+| `scope` | [`[Int!]!`](../scalar/int.md) | The scope of the reference value. |
 | `updatedAt` | [`Time!`](../scalar/time.md) | Time when this ReferenceValue was last updated |
 


### PR DESCRIPTION
This intentionally only changes the GraphQL type because it isn't yet clear how this change affects the other backend components. It is therefore expected to break until the other components are updated.