### PR TITLE
Fix DataTypes::UpdateService to not be order dependent for received DataTypes

### DIFF
--- a/app/models/json_schemas/GenericMapper.json
+++ b/app/models/json_schemas/GenericMapper.json
@@ -3,13 +3,29 @@
   "$id": "https://example.com/schemas/GenericMapper.json",
   "title": "GenericMapper",
   "type": "object",
-  "required": ["source", "target"],
+  "required": [
+    "source",
+    "target",
+    "generic_combinations"
+  ],
   "properties": {
     "source": {
-      "$ref": "DataTypeIdentifier.json"
+      "type": "array",
+      "items": {
+        "$ref": "DataTypeIdentifier.json"
+      }
     },
     "target": {
       "type": "string"
+    },
+    "generic_combinations": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "AND",
+          "OR"
+        ]
+      }
     }
   }
 }

--- a/lib/sagittarius/validators/json_schema_validator.rb
+++ b/lib/sagittarius/validators/json_schema_validator.rb
@@ -25,9 +25,10 @@ module Sagittarius
         value = JSON.parse(value.to_s) if options[:parse_json] == true && !value.nil?
 
         if options[:detail_errors]
-          JSON::Validator.validate(schema, value).each do |error|
-            message = format_error_message(error)
-            record.errors.add(attribute, message)
+          begin
+            JSON::Validator.validate!(schema_path, value)
+          rescue JSON::Schema::ValidationError, JSON::Schema::SchemaError => e
+            record.errors.add(attribute, e.message)
           end
         else
           record.errors.add(attribute, error_message) unless valid_schema?(value)


### PR DESCRIPTION
Also fixes the detail option for the JsonSchemaValidator and the JsonSchema for the GenericMapper

Closes #825